### PR TITLE
fix: forces note-c to compile under zephyr with c11

### DIFF
--- a/Kconfig.notecard
+++ b/Kconfig.notecard
@@ -1,10 +1,9 @@
 menuconfig BLUES_NOTECARD
+	select REQUIRES_STD_C11
 	bool "Enable Blues Notecard libraries"
 	help
-	  Enable Blues Notecard Libraries to communicate with the Notecard
+	  Enable Blues Notecard Libraries to communicate with the Notecard (requires C11)
 
 if BLUES_NOTECARD
-
 rsource "notecard/Kconfig"
-
 endif # BLUES_NOTECARD

--- a/notecard/CMakeLists.txt
+++ b/notecard/CMakeLists.txt
@@ -1,4 +1,5 @@
 zephyr_library()
+
 zephyr_library_sources(
 	../note-c/n_atof.c
 	../note-c/n_b64.c


### PR DESCRIPTION
Fixes issue relating to `static_assert` being unreferenced in Zephyr (likely due to C99 being used rather than C11). This change forces Zephyr to build `note-c` with the C11 standard.