### PR TITLE
fix: add missing n_cobs.c source file needed for binary examples

### DIFF
--- a/notecard/CMakeLists.txt
+++ b/notecard/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_library_sources(
 	../note-c/n_b64.c
 	../note-c/n_cjson.c
 	../note-c/n_cjson_helpers.c
+	../note-c/n_cobs.c
 	../note-c/n_const.c
 	../note-c/n_ftoa.c
 	../note-c/n_helpers.c


### PR DESCRIPTION
The n_cobs.c file is needed when building binary examples. Without it, the build fails due to missing _cobs* symbol references in n_helpers.c

Testing:-
- Tested that an example with NoteBinaryStoreTransmit/NoteBinaryStoreReset builds without an issue. Prior to the commit, the build would fail with "undefined reference to _cobsEncode, _cobsEncodedLength, _cobsEncodedMaxLength, etc.
- Tested that the blinky and message-queues examples still build.