### PR TITLE
ci: build examples against Zephyr 3.7 LTS, 4.3, and 4.4

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -19,6 +19,10 @@ jobs:
         overlay:
           - i2c.overlay
           - uart.overlay
+        zephyr-version:
+          - v3.7.0
+          - v4.3.0
+          - v4.4.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,6 +30,10 @@ jobs:
           path: note-zephyr
           fetch-depth: 1
           submodules: recursive
+
+      - name: Set Zephyr version
+        run: |
+          sed -i 's/revision: .*/revision: ${{ matrix.zephyr-version }}/' note-zephyr/west.yml
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -38,7 +46,7 @@ jobs:
           app-path: note-zephyr
           toolchains: arm-zephyr-eabi
 
-      - name: Build ${{ matrix.example }} with ${{ matrix.overlay }}
+      - name: Build ${{ matrix.example }} with ${{ matrix.overlay }} (Zephyr ${{ matrix.zephyr-version }})
         working-directory: note-zephyr/examples/${{ matrix.example }}
         shell: bash
         run: |

--- a/examples/message-queues/src/main.c
+++ b/examples/message-queues/src/main.c
@@ -8,7 +8,7 @@
 LOG_MODULE_REGISTER(main, CONFIG_LOG_DEFAULT_LEVEL);
 
 #define BUTTON_NODE DT_ALIAS(sw0)
-#if !DT_NODE_HAS_STATUS_OKAY(BUTTON_NODE)
+#if !DT_NODE_HAS_STATUS(BUTTON_NODE, okay)
 #error "Unsupported board: sw0 devicetree alias is not defined"
 #endif
 #define BUTTON_PIN  DT_GPIO_PIN(BUTTON_NODE, gpios)

--- a/west.yml
+++ b/west.yml
@@ -6,5 +6,6 @@ manifest:
       url: https://github.com/zephyrproject-rtos/zephyr
       import:
         name-allowlist:
+          - cmsis
           - cmsis_6
           - hal_stm32


### PR DESCRIPTION
## Summary

- Adds `zephyr-version` as a matrix dimension (`v3.7.0`, `v4.3.0`, `v4.4.0`) to the existing build matrix
- Adds a step before `action-zephyr-setup` that patches `west.yml` with the target Zephyr revision
- Expands total CI jobs from 6 → 18 (3 examples × 2 overlays × 3 Zephyr versions)

## Test plan

- [x] Confirm all 18 matrix jobs pass on this PR
- [x] Verify job names show the Zephyr version for easy identification in the Actions UI